### PR TITLE
Bad default image pull policy

### DIFF
--- a/deploy/storage-check-vsphere.yaml
+++ b/deploy/storage-check-vsphere.yaml
@@ -19,7 +19,7 @@ spec:
         - name: MAX_FAILURES_ALLOWED
           value: "9"
       image: chrishirsch/kuberhealthy-storage-check:v0.0.1
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       name: main
       resources:
         requests:

--- a/deploy/storage-check.yaml
+++ b/deploy/storage-check.yaml
@@ -10,7 +10,7 @@ spec:
   podSpec:
     containers:
     - image: chrishirsch/kuberhealthy-storage-check:v0.0.1
-      imagePullPolicy: Always
+      imagePullPolicy: IfNotPresent
       name: main
       resources:
         requests:


### PR DESCRIPTION
Closes #12 

Had a bad default imagePullPolicy of always instead of ifNotPresent which was causing a pull from docker.io every time a new pod was created (if the default wasn't changed). This would result in being rate limited by docker.io and frankly wasn't needed anyway.