### PR TITLE
add extra check to verify node to test is still schedulable

### DIFF
--- a/cmd/storage-check/storage.go
+++ b/cmd/storage-check/storage.go
@@ -94,7 +94,7 @@ func createStorageConfig(pvcname string) *corev1.PersistentVolumeClaim {
 	// Add the storage spec to the storage.
 	pvc.Spec = pvcSpec
 
-	log.Infoln("PVC ", pvcname, " is", pvc, "namespace environment variables:chris", additionalEnvVars)
+	log.Debugln("PVC", pvcname, "is", pvc, "namespace environment variables:chris", additionalEnvVars)
 	return pvc
 }
 
@@ -154,7 +154,7 @@ func initializeStorageConfig(jobName string, pvcName string) *batchv1.Job {
 	// Add the storage spec to the storage.
 	job.Spec = jobSpec
 
-	log.Infoln("Job ", jobName, " is", job, "namespace environment variables:", additionalEnvVars)
+	log.Debugln("Job", jobName, "is", job, "namespace environment variables:", additionalEnvVars)
 	return job
 }
 
@@ -214,7 +214,7 @@ func checkNodeConfig(jobName string, pvcName string, node string) *batchv1.Job {
 	// Add the storage spec to the storage.
 	job.Spec = jobSpec
 
-	log.Infoln("Job ", jobName, " is", job, "namespace environment variables:", additionalEnvVars)
+	log.Debugln("Job", jobName, "is", job, "namespace environment variables:", additionalEnvVars)
 	return job
 }
 


### PR DESCRIPTION
With many nodes and frequent Karpenter consolidations or AWS spot interruptions the nodes further down the list first gathered at the start of running the check, may be terminated.

This can lead to false positives.

To mitigate this, we can check if the node is still present before running the check.